### PR TITLE
Update hero tagline position and logo sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,10 +39,11 @@
     <div class="hero-logo-container">
       <img src="Logo_White_Transparente.png" alt="Logotipo de MX Analytics" class="hero-logo">
     </div>
-    <h1>Impulsa tu negocio con datos de valor</h1>
     <a class="cta-btn" href="#contacto">Contáctanos</a>
   </div>
 </section>
+
+<h1 class="page-title">Impulsa tu negocio con datos de valor</h1>
 
 <section id="sobre" class="card">
   <h2>Sobre nosotros</h2>

--- a/style.css
+++ b/style.css
@@ -98,6 +98,14 @@ h2 {
   font-weight: 600;
 }
 
+.page-title {
+  text-align: center;
+  margin: 1.5rem 0;
+  color: #31678D;
+  font-size: 2rem;
+  font-weight: 600;
+}
+
 .cta-btn {
   display: inline-block;
   margin-top: 0.5rem;
@@ -165,6 +173,8 @@ h2 {
 @media (min-width: 768px) {
   .nav { width: 40%; }
   .card { width: 80%; }
+  .hero-logo-container { transform: scale(0.75); }
+  .hero-logo { max-width: 60%; }
 }
 
 /* Tarjetas colapsables en la sección de servicios */


### PR DESCRIPTION
## Summary
- reposition hero tagline below the cover section
- add `.page-title` styles
- shrink hero logo on desktop

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a98ae204c8325b2773ec07b32f4a5